### PR TITLE
Require Jenkins 2.361.4 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,9 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useContainerAgent: true)
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'windows', jdk: 17],
+])

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 ## Introduction
 
-Markdown Formatter
+Markdown Formatter allows plain text to be converted into HTML in Jenkins.
+The formatter uses [CommonMark](https://commonmark.org/).
 
 ## Getting started
 
@@ -22,4 +23,3 @@ Refer to our [contribution guidelines](https://github.com/jenkinsci/.github/blob
 ## LICENSE
 
 Licensed under MIT, see [LICENSE](LICENSE.md)
-

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.40</version>
+        <version>4.54</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -14,9 +14,8 @@
     <properties>
         <revision>0.2.1</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.235.1</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <commonmark.version>0.21.0</commonmark.version>
-        <java.level>8</java.level>
     </properties>
     <name>Markdown Formatter</name>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
@@ -25,8 +24,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.235.x</artifactId>
-                <version>918.vae501d2cdc99</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1798.vc671fe94856f</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -41,7 +40,7 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>${scmTag}</tag>


### PR DESCRIPTION
## Require Jenkins 2.361.4 or newer

https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ recommends either 2.346.3 or 2.361.4 as good core dependencies.  40% of the existing installations are already running Jenkins 2.361.1 or newer.  This update encourages the other users to update to the most recent release.

Updates the SCM URL to avoid a warning from the pom file.

Tests with Java 11 and Java 17

This removes the implied dependency on sshd plugin and others so that this plugin won't risk preventing removal of ace-editor plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
