### PR TITLE
Depend on JSON API plugin, not outdated transitive dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,18 @@
       <groupId>com.vdurmont</groupId>
       <artifactId>emoji-java</artifactId>
       <version>5.1.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Depend on JSON API plugin rather than the transitive
+x         dependency of the old JSON API from emoji-java -->
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>json-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonmark</groupId>


### PR DESCRIPTION
## Depend on JSON API plugin, not outdated transitive dependency

The emoji-java library has a transitive dependency on a 2017 version of the JSON library.  The licensing of the 2017 version of the JSON library is not as clear as the licensing of the most recent library version.

The most recent library version is available as a Jenkins API plugin.  Depend on the Jenkins JSON API plugin instead of bundling the old JSON API jar file in the plugin.

### Testing done

None, yet.  Will test interactively to assure it is well behaved.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
