### PR TITLE
Enable syntax highlighting when editing markdown text

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,21 @@ The formatter uses [CommonMark](https://commonmark.org/).
 
 ## Getting started
 
-In Manage Jenkins -> Security -> Markup Formatter
-select "Markdown Formatter" from the drop down list.
+In Manage Jenkins -> Security -> Markup Formatter select "Markdown Formatter" from the drop down list.
+
+Markdown syntax highlighting is enabled by default while editing the markdown text in the Jenkins pages.
+A configuration checkbox is available in the "Security" page to disable syntax highlighting while editing markdown text in Jenkins.
+
+## Configuration as code
+
+The [configuration as code plugin](https://plugins.jenkins.io/configuration-as-code/) can define the markup formatter and its configuration.
+
+```yaml
+jenkins:
+  markupFormatter:
+    markdownFormatter:
+      disableSyntaxHighlighting: false
+```
 
 ## Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,17 @@ x         dependency of the old JSON API from emoji-java -->
       <artifactId>commonmark-ext-ins</artifactId>
       <version>${commonmark.version}</version>
     </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/MarkdownFormatter.java
+++ b/src/main/java/io/jenkins/plugins/MarkdownFormatter.java
@@ -22,8 +22,12 @@ public class MarkdownFormatter extends MarkupFormatter {
     private static Parser markdownParser = null;
     // private static MutableDataSet options = new MutableDataSet();
 
+    private final boolean disableSyntaxHighlighting;
+
     @DataBoundConstructor
-    public MarkdownFormatter() {}
+    public MarkdownFormatter(boolean disableSyntaxHighlighting) {
+        this.disableSyntaxHighlighting = disableSyntaxHighlighting;
+    }
 
     static {
         List<org.commonmark.Extension> extensions = Arrays.asList(
@@ -39,6 +43,10 @@ public class MarkdownFormatter extends MarkupFormatter {
         markdownParser = Parser.builder().extensions(extensions).build();
     }
 
+    public boolean isDisableSyntaxHighlighting() {
+        return disableSyntaxHighlighting;
+    }
+
     @Override
     public void translate(String markup, Writer output) throws IOException {
         if (markup != null) {
@@ -47,6 +55,10 @@ public class MarkdownFormatter extends MarkupFormatter {
         } else {
             output.write("");
         }
+    }
+
+    public String getCodeMirrorMode() {
+        return disableSyntaxHighlighting ? null : "markdown";
     }
 
     @Extension

--- a/src/main/java/io/jenkins/plugins/MarkdownFormatter.java
+++ b/src/main/java/io/jenkins/plugins/MarkdownFormatter.java
@@ -24,6 +24,12 @@ public class MarkdownFormatter extends MarkupFormatter {
 
     private final boolean disableSyntaxHighlighting;
 
+    /** @deprecated */
+    @Deprecated
+    public MarkdownFormatter() {
+        this(true);
+    }
+
     @DataBoundConstructor
     public MarkdownFormatter(boolean disableSyntaxHighlighting) {
         this.disableSyntaxHighlighting = disableSyntaxHighlighting;

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.jelly
@@ -1,6 +1,9 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:description>
-        This markup formatter supports markdown
+        ${%blurb}
     </f:description>
+    <f:entry field="disableSyntaxHighlighting">
+        <f:checkbox title="${%disableSyntaxHighlighting}"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
@@ -1,0 +1,2 @@
+blurb=This markup formatter supports markdown
+disableSyntaxHighlighting=Disable syntax highlighting

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
@@ -1,2 +1,2 @@
 blurb=This markup formatter supports markdown
-disableSyntaxHighlighting=Disable syntax highlighting
+disableSyntaxHighlighting=Disable syntax highlighting when editing markdown text

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help-disableSyntaxHighlighting.html
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help-disableSyntaxHighlighting.html
@@ -1,4 +1,5 @@
 <div>
-	Use syntax highlighting while editing the markdown text.
-	Does not change the display of markdown rendering in the final page, only while editing.
+  Do not use syntax highlighting while editing the markdown text.
+  Syntax highlighting applies only while editing the text.
+  It does not change the display of markdown rendering in the final page.
 </div>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help-disableSyntaxHighlighting.html
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help-disableSyntaxHighlighting.html
@@ -1,0 +1,4 @@
+<div>
+	Use syntax highlighting while editing the markdown text.
+	Does not change the display of markdown rendering in the final page, only while editing.
+</div>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help.html
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help.html
@@ -1,0 +1,4 @@
+<div>
+	Convert markdown formatted text into HTML in Jenkins job descriptions and other text fields.
+	The plugin uses <a href="https://commonmark.org/">CommonMark</a>.
+</div>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help.html
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help.html
@@ -1,4 +1,4 @@
 <div>
-	Convert markdown formatted text into HTML in Jenkins job descriptions and other text fields.
-	The plugin uses <a href="https://commonmark.org/">CommonMark</a>.
+  Convert markdown formatted text into HTML in Jenkins job descriptions and other text fields.
+  The plugin uses <a href="https://commonmark.org/">CommonMark</a>.
 </div>

--- a/src/test/java/io/jenkins/plugins/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/ConfigurationAsCodeTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
@@ -15,7 +16,7 @@ public class ConfigurationAsCodeTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code.yaml")
-    public void should_support_configuration_as_code() {
+    public void should_support_configuration_as_code_with_highlighting_disabled() {
         Jenkins jenkins = jenkinsRule.jenkins;
 
         assertTrue(
@@ -23,6 +24,32 @@ public class ConfigurationAsCodeTest {
                 jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
         assertTrue(
                 "Formatter should be configured with syntax highlighting disabled",
+                ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-with-syntax-highlighting.yaml")
+    public void should_support_configuration_as_code_with_highlighting_enabled() {
+        Jenkins jenkins = jenkinsRule.jenkins;
+
+        assertTrue(
+                "Markdown markup formatter should be configured",
+                jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
+        assertFalse(
+                "Formatter should be configured with syntax highlighting enabled",
+                ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-191.yaml") // Release 191.vf7955d4d081b_ 25 Jun 2024
+    public void should_support_configuration_as_code_legacy() {
+        Jenkins jenkins = jenkinsRule.jenkins;
+
+        assertTrue(
+                "Markdown markup formatter should be configured",
+                jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
+        assertFalse(
+                "Formatter should be configured with syntax highlighting enabled",
                 ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
     }
 }

--- a/src/test/java/io/jenkins/plugins/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/ConfigurationAsCodeTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins;
+
+import static org.junit.Assert.assertTrue;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ConfigurationAsCodeTest {
+
+    @Rule
+    public JenkinsConfiguredWithCodeRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yaml")
+    public void should_support_configuration_as_code() {
+        Jenkins jenkins = jenkinsRule.jenkins;
+
+        assertTrue(
+                "Markdown markup formatter should be configured",
+                jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
+        assertTrue(
+                "Formatter should be configured with syntax highlighting disabled",
+                ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/MarkdownFormatterTest.java
+++ b/src/test/java/io/jenkins/plugins/MarkdownFormatterTest.java
@@ -33,6 +33,15 @@ public class MarkdownFormatterTest {
     }
 
     @Test
+    @Deprecated
+    public void handlesSyntaxHighlightingDisabledDeprecatedConstructor() {
+        MarkdownFormatter formatter = new MarkdownFormatter();
+
+        assertTrue("Syntax highlighting should be disabled", formatter.isDisableSyntaxHighlighting());
+        assertNull("Code mirror code should not be set", formatter.getCodeMirrorMode());
+    }
+
+    @Test
     public void handlesMarkdown() throws Exception {
         // basic markdown
         assertEquals(

--- a/src/test/java/io/jenkins/plugins/MarkdownFormatterTest.java
+++ b/src/test/java/io/jenkins/plugins/MarkdownFormatterTest.java
@@ -13,7 +13,23 @@ public class MarkdownFormatterTest {
 
     @Before
     public void setup() {
-        j.jenkins.setMarkupFormatter(new MarkdownFormatter());
+        j.jenkins.setMarkupFormatter(new MarkdownFormatter(false));
+    }
+
+    @Test
+    public void handlesSyntaxHighlightingEnabled() {
+        MarkdownFormatter formatter = new MarkdownFormatter(false);
+
+        assertFalse("Syntax highlighting should be enabled", formatter.isDisableSyntaxHighlighting());
+        assertEquals("Code mirror code should be set", "markdown", formatter.getCodeMirrorMode());
+    }
+
+    @Test
+    public void handlesSyntaxHighlightingDisabled() {
+        MarkdownFormatter formatter = new MarkdownFormatter(true);
+
+        assertTrue("Syntax highlighting should be disabled", formatter.isDisableSyntaxHighlighting());
+        assertNull("Code mirror code should not be set", formatter.getCodeMirrorMode());
     }
 
     @Test

--- a/src/test/resources/io/jenkins/plugins/configuration-as-code-191.yaml
+++ b/src/test/resources/io/jenkins/plugins/configuration-as-code-191.yaml
@@ -1,0 +1,2 @@
+jenkins:
+  markupFormatter: "markdownFormatter"

--- a/src/test/resources/io/jenkins/plugins/configuration-as-code-with-syntax-highlighting.yaml
+++ b/src/test/resources/io/jenkins/plugins/configuration-as-code-with-syntax-highlighting.yaml
@@ -1,0 +1,4 @@
+jenkins:
+  markupFormatter:
+    markdownFormatter:
+      disableSyntaxHighlighting: false

--- a/src/test/resources/io/jenkins/plugins/configuration-as-code.yaml
+++ b/src/test/resources/io/jenkins/plugins/configuration-as-code.yaml
@@ -1,0 +1,4 @@
+jenkins:
+  markupFormatter:
+    markdownFormatter:
+      disableSyntaxHighlighting: true


### PR DESCRIPTION
Add code mirror configuration to enable syntax highlighting.

Highlighting can be disabled in the  formatter configuration.

Some additional enhancements:
* Add test case for configuration-as-code.
* Move texts in properties file to support multi languages

Existing users will have syntax editing enabled by default during edits of the markdown text.  If they want to remove this new capability, they can use either the "Disable syntax highlighting when editing markdown text" checkbox or the configuration as code setting.

### Testing done

Installed on local instance. Tests with manually configuration and via configuration as code.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
