### PR TITLE
Use correct capitalization of 'Markdown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ The formatter uses [CommonMark](https://commonmark.org/).
 
 ## Getting started
 
-In Manage Jenkins -> Security -> Markup Formatter select "Markdown Formatter" from the drop down list.
+In Manage Jenkins -> Security -> Markup Formatter select "Markdown Formatter" from the drop-down list.
 
-Markdown syntax highlighting is enabled by default while editing the markdown text in the Jenkins pages.
-A configuration checkbox is available in the "Security" page to disable syntax highlighting while editing markdown text in Jenkins.
+Markdown syntax highlighting is enabled by default while editing the Markdown text in the Jenkins pages.
+A configuration checkbox is available in the "Security" page to disable syntax highlighting while editing Markdown text in Jenkins.
 
 ## Configuration as code
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    This plugin adds markdown support
+    This plugin adds Markdown support for formatted text using <a href="https://commonmark.org/">CommonMark</a>.
 </div>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:description>
-        ${%description}
+        ${%blurb}
     </f:description>
     <f:entry field="disableSyntaxHighlighting">
         <f:checkbox title="${%disableSyntaxHighlighting}"/>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:description>
-        ${%blurb}
+        ${%description}
     </f:description>
     <f:entry field="disableSyntaxHighlighting">
         <f:checkbox title="${%disableSyntaxHighlighting}"/>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
@@ -1,2 +1,2 @@
-description=This markup formatter supports Markdown
+blurb=This markup formatter supports Markdown
 disableSyntaxHighlighting=Disable syntax highlighting when editing Markdown text

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/config.properties
@@ -1,2 +1,2 @@
-blurb=This markup formatter supports markdown
-disableSyntaxHighlighting=Disable syntax highlighting when editing markdown text
+description=This markup formatter supports Markdown
+disableSyntaxHighlighting=Disable syntax highlighting when editing Markdown text

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help-disableSyntaxHighlighting.html
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help-disableSyntaxHighlighting.html
@@ -1,5 +1,5 @@
 <div>
-  Do not use syntax highlighting while editing the markdown text.
+  Do not use syntax highlighting while editing the Markdown text.
   Syntax highlighting applies only while editing the text.
-  It does not change the display of markdown rendering in the final page.
+  It does not change the display of Markdown rendering in the final page.
 </div>

--- a/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help.html
+++ b/src/main/resources/io/jenkins/plugins/MarkdownFormatter/help.html
@@ -1,4 +1,4 @@
 <div>
-  Convert markdown formatted text into HTML in Jenkins job descriptions and other text fields.
+  Convert Markdown formatted text into HTML in Jenkins job descriptions and other text fields.
   The plugin uses <a href="https://commonmark.org/">CommonMark</a>.
 </div>

--- a/src/test/java/io/jenkins/plugins/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/ConfigurationAsCodeTest.java
@@ -1,55 +1,48 @@
 package io.jenkins.plugins;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import jenkins.model.Jenkins;
-import org.junit.Rule;
-import org.junit.Test;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import org.junit.jupiter.api.Test;
 
-public class ConfigurationAsCodeTest {
-
-    @Rule
-    public JenkinsConfiguredWithCodeRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
+@WithJenkinsConfiguredWithCode
+class ConfigurationAsCodeTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code.yaml")
-    public void should_support_configuration_as_code_with_highlighting_disabled() {
-        Jenkins jenkins = jenkinsRule.jenkins;
-
+    void should_support_configuration_as_code_with_highlighting_disabled(JenkinsConfiguredWithCodeRule r) {
+        assertInstanceOf(
+                MarkdownFormatter.class,
+                r.jenkins.getMarkupFormatter(),
+                "Markdown markup formatter should be configured");
         assertTrue(
-                "Markdown markup formatter should be configured",
-                jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
-        assertTrue(
-                "Formatter should be configured with syntax highlighting disabled",
-                ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
+                ((MarkdownFormatter) r.jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting(),
+                "Formatter should be configured with syntax highlighting disabled");
     }
 
     @Test
     @ConfiguredWithCode("configuration-as-code-with-syntax-highlighting.yaml")
-    public void should_support_configuration_as_code_with_highlighting_enabled() {
-        Jenkins jenkins = jenkinsRule.jenkins;
-
-        assertTrue(
-                "Markdown markup formatter should be configured",
-                jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
+    void should_support_configuration_as_code_with_highlighting_enabled(JenkinsConfiguredWithCodeRule r) {
+        assertInstanceOf(
+                MarkdownFormatter.class,
+                r.jenkins.getMarkupFormatter(),
+                "Markdown markup formatter should be configured");
         assertFalse(
-                "Formatter should be configured with syntax highlighting enabled",
-                ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
+                ((MarkdownFormatter) r.jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting(),
+                "Formatter should be configured with syntax highlighting enabled");
     }
 
     @Test
     @ConfiguredWithCode("configuration-as-code-191.yaml") // Release 191.vf7955d4d081b_ 25 Jun 2024
-    public void should_support_configuration_as_code_legacy() {
-        Jenkins jenkins = jenkinsRule.jenkins;
-
-        assertTrue(
-                "Markdown markup formatter should be configured",
-                jenkins.getMarkupFormatter() instanceof MarkdownFormatter);
+    void should_support_configuration_as_code_legacy(JenkinsConfiguredWithCodeRule r) {
+        assertInstanceOf(
+                MarkdownFormatter.class,
+                r.jenkins.getMarkupFormatter(),
+                "Markdown markup formatter should be configured");
         assertFalse(
-                "Formatter should be configured with syntax highlighting enabled",
-                ((MarkdownFormatter) jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting());
+                ((MarkdownFormatter) r.jenkins.getMarkupFormatter()).isDisableSyntaxHighlighting(),
+                "Formatter should be configured with syntax highlighting enabled");
     }
 }

--- a/src/test/java/io/jenkins/plugins/MarkdownFormatterTest.java
+++ b/src/test/java/io/jenkins/plugins/MarkdownFormatterTest.java
@@ -1,79 +1,81 @@
 package io.jenkins.plugins;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class MarkdownFormatterTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class MarkdownFormatterTest {
 
-    @Before
-    public void setup() {
-        j.jenkins.setMarkupFormatter(new MarkdownFormatter(false));
+    private JenkinsRule r;
+
+    @BeforeEach
+    void setup(JenkinsRule r) {
+        this.r = r;
+        this.r.jenkins.setMarkupFormatter(new MarkdownFormatter(false));
     }
 
     @Test
-    public void handlesSyntaxHighlightingEnabled() {
+    void handlesSyntaxHighlightingEnabled() {
         MarkdownFormatter formatter = new MarkdownFormatter(false);
 
-        assertFalse("Syntax highlighting should be enabled", formatter.isDisableSyntaxHighlighting());
-        assertEquals("Code mirror code should be set", "markdown", formatter.getCodeMirrorMode());
+        assertFalse(formatter.isDisableSyntaxHighlighting(), "Syntax highlighting should be enabled");
+        assertEquals("markdown", formatter.getCodeMirrorMode(), "Code mirror code should be set");
     }
 
     @Test
-    public void handlesSyntaxHighlightingDisabled() {
+    void handlesSyntaxHighlightingDisabled() {
         MarkdownFormatter formatter = new MarkdownFormatter(true);
 
-        assertTrue("Syntax highlighting should be disabled", formatter.isDisableSyntaxHighlighting());
-        assertNull("Code mirror code should not be set", formatter.getCodeMirrorMode());
+        assertTrue(formatter.isDisableSyntaxHighlighting(), "Syntax highlighting should be disabled");
+        assertNull(formatter.getCodeMirrorMode(), "Code mirror code should not be set");
     }
 
     @Test
     @Deprecated
-    public void handlesSyntaxHighlightingDisabledDeprecatedConstructor() {
+    void handlesSyntaxHighlightingDisabledDeprecatedConstructor() {
         MarkdownFormatter formatter = new MarkdownFormatter();
 
-        assertTrue("Syntax highlighting should be disabled", formatter.isDisableSyntaxHighlighting());
-        assertNull("Code mirror code should not be set", formatter.getCodeMirrorMode());
+        assertTrue(formatter.isDisableSyntaxHighlighting(), "Syntax highlighting should be disabled");
+        assertNull(formatter.getCodeMirrorMode(), "Code mirror code should not be set");
     }
 
     @Test
-    public void handlesMarkdown() throws Exception {
+    void handlesMarkdown() throws Exception {
         // basic markdown
         assertEquals(
                 "<p><em>bold</em></p>",
-                j.jenkins.getMarkupFormatter().translate("*bold*").trim());
+                r.jenkins.getMarkupFormatter().translate("*bold*").trim());
     }
 
     @Test
-    public void handlesEmoji() throws Exception {
+    void handlesEmoji() throws Exception {
         // basic markdown
         assertEquals(
                 "<p>\uD83D\uDE8C</p>",
-                j.jenkins.getMarkupFormatter().translate(":bus:").trim());
+                r.jenkins.getMarkupFormatter().translate(":bus:").trim());
     }
 
     @Test
-    public void defaultEscaped() throws Exception {
+    void defaultEscaped() throws Exception {
         // basic markdown
         assertEquals(
                 "<p><em>bold</em></p>",
-                j.jenkins.getMarkupFormatter().translate("*bold*").trim());
+                r.jenkins.getMarkupFormatter().translate("*bold*").trim());
         // html gets escaped
         assertEquals(
                 "<p>&lt;ul&gt;&lt;li&gt;list&lt;/li&gt;&lt;/ul&gt;</p>",
-                j.jenkins
+                r.jenkins
                         .getMarkupFormatter()
                         .translate("<ul><li>list</li></ul>")
                         .trim());
         // basic link
         assertEquals(
                 "<p><a rel=\"nofollow\" href=\"http://www.youtube.com/watch?v=YOUTUBE_VIDEO_ID_HERE\"><img src=\"http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg\" alt=\"IMAGE ALT TEXT HERE\" /></a></p>",
-                j.jenkins
+                r.jenkins
                         .getMarkupFormatter()
                         .translate(
                                 "[![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg)](http://www.youtube.com/watch?v=YOUTUBE_VIDEO_ID_HERE)")
@@ -81,7 +83,7 @@ public class MarkdownFormatterTest {
         // basic xss gets escaped
         assertEquals(
                 "<p><a rel=\"nofollow\" href=\"\">some text</a></p>",
-                j.jenkins
+                r.jenkins
                         .getMarkupFormatter()
                         .translate("[some text](javascript:alert('xss'))")
                         .trim());
@@ -90,21 +92,21 @@ public class MarkdownFormatterTest {
                 "<p>hello &lt;a name=&quot;n&quot;</p>\n" + "<blockquote>\n"
                         + "<p>href=&quot;javascript:alert('xss')&quot;&gt;<em>you</em>&lt;/a&gt;</p>\n"
                         + "</blockquote>",
-                j.jenkins
+                r.jenkins
                         .getMarkupFormatter()
                         .translate("hello <a name=\"n\"\n" + "> href=\"javascript:alert('xss')\">*you*</a>")
                         .trim());
         // more complex XSS
         assertEquals(
                 "<p>Payload: <a rel=\"nofollow\" href=\"\">click me</a></p>",
-                j.jenkins
+                r.jenkins
                         .getMarkupFormatter()
                         .translate("Payload: [click me](javascript&#X3a;alert`XSS`)")
                         .trim());
     }
 
     @Test
-    public void handlesNull() throws Exception {
-        assertEquals("", j.jenkins.getMarkupFormatter().translate(null).trim());
+    void handlesNull() throws Exception {
+        assertEquals("", r.jenkins.getMarkupFormatter().translate(null).trim());
     }
 }


### PR DESCRIPTION
This PR includes the following Code Quality improvements:

* Upgrade tests to JUnit5
* Consistent spelling of `Markdown` with uppercase M (its a language, so uppercase should be used)
* Remove static code block from `MarkdownFormatter` in favour of final fields
* Minor code cleanup and pretty-printing

### Testing done
`mvn clean verify` without issues.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
