### PR TITLE
Remove developers section from pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,25 +23,6 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>halkeye</id>
-      <name>Gavin Mogan</name>
-      <email>jenkins@gavinmogan.com</email>
-      <roles>
-        <role>developer</role>
-      </roles>
-    </developer>
-    <developer>
-      <id>markewaite</id>
-      <name>Mark Waite</name>
-      <email>mark.earl.waite@gmail.com</email>
-      <roles>
-        <role>developer</role>
-      </roles>
-    </developer>
-  </developers>
-
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>


### PR DESCRIPTION
## Remove developers section from pom file

The repository permissions updater is the definitive list of plugin developers.  The plugin archetype has not suggested a `<developers>` section since the 2022 merge of:

* https://github.com/jenkinsci/archetypes/pull/515

Rather than carry duplicated information in the pom.xml file, remove the `<developers>` section to better match the plugin archetype and further reduce the maintenance burden.

### Testing done

Compiled plugin locally to confirm it still builds after this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
