### PR TITLE
Declare dependencies and ban JUnit 4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.19</version>
+    <version>5.22</version>
     <relativePath />
   </parent>
 
@@ -34,12 +34,15 @@
     <changelist>999999-SNAPSHOT</changelist>
     <commonmark.version>0.25.1</commonmark.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <hpi.bundledArtifacts>autolink,commonmark,commonmark-ext-autolink,commonmark-ext-gfm-strikethrough,commonmark-ext-gfm-tables,commonmark-ext-heading-anchor,commonmark-ext-ins,emoji-java</hpi.bundledArtifacts>
+    <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.492</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Declare dependencies and ban JUnit 4 imports

Declare the dependencies that are bundled in the plugin hpi file.  Avoid inadvertent introduction of new dependencies.

Plugin tests are implemented in JUnit 5.  Ban JUnit 4 imports so that new tests do not introduce tests based on JUnit 4.

### Testing done

Confirmed that compilation succeeds.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
